### PR TITLE
Resolved issue while preparing httpBody for fetchToken URLRequest.

### DIFF
--- a/twiliochat/TokenRequestHandler.swift
+++ b/twiliochat/TokenRequestHandler.swift
@@ -11,7 +11,7 @@ class TokenRequestHandler {
                 if !data.isEmpty {
                     data = data + "&"
                 }
-                data = encodedKey + "=" + encodedValue;
+                data = data + encodedKey + "=" + encodedValue;
             }
         }
         


### PR DESCRIPTION
…d in TokenRequestHandler.swift class when we are passing [String:String] into this method it was returning only last parameter on dictionary there was a bug in Line no. 14 previously it was data = encodedKey + = + encodedValue;   it should be  data = data + encodedKey + = + encodedValue;